### PR TITLE
Add batching to CSV import.

### DIFF
--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -25,7 +25,7 @@
   "author": "Logion Team",
   "license": "Apache-2.0",
   "dependencies": {
-    "@logion/node-api": "^0.26.0"
+    "@logion/node-api": "^0.27.0-2"
   },
   "bugs": {
     "url": "https://github.com/logion-network/logion-tools/issues"

--- a/packages/csv/src/BatchMaker.ts
+++ b/packages/csv/src/BatchMaker.ts
@@ -1,0 +1,20 @@
+
+export class BatchMaker<T> {
+
+    private readonly source: T[];
+    readonly batchSize: number;
+    readonly numOfBatches: number
+
+    constructor(source: T[], batchSize: number) {
+        this.source = source;
+        this.batchSize = batchSize;
+        this.numOfBatches = Math.ceil(source.length / batchSize);
+    }
+
+    getBatch(index: number): T[] {
+        if (index >= this.numOfBatches) {
+            throw Error("index out-of-range")
+        }
+        return this.source.slice(index * this.batchSize, (index + 1) * this.batchSize)
+    }
+}

--- a/packages/csv/test/BatchMaker.spec.ts
+++ b/packages/csv/test/BatchMaker.spec.ts
@@ -1,0 +1,29 @@
+import { BatchMaker } from "../src/BatchMaker.js";
+
+describe("BatchMaker", () => {
+
+    const source = [0, 1, 2, 3, 4, 5];
+
+    it("provides same size batches", () => {
+        const batchMaker = new BatchMaker(source, 3);
+        expect(batchMaker.numOfBatches).toEqual(2);
+        expect(batchMaker.getBatch(0)).toEqual([0,1,2]);
+        expect(batchMaker.getBatch(1)).toEqual([3,4,5]);
+        expect(() => batchMaker.getBatch(2)).toThrowError("index out-of-range");
+    })
+
+    it("provides smaller last batch", () => {
+        const batchMaker = new BatchMaker(source, 4);
+        expect(batchMaker.numOfBatches).toEqual(2);
+        expect(batchMaker.getBatch(0)).toEqual([0,1,2,3]);
+        expect(batchMaker.getBatch(1)).toEqual([4,5]);
+        expect(() => batchMaker.getBatch(2)).toThrowError("index out-of-range");
+    })
+
+    it("provides at least one batch", () => {
+        const batchMaker = new BatchMaker(source, 10);
+        expect(batchMaker.numOfBatches).toEqual(1);
+        expect(batchMaker.getBatch(0)).toEqual([0, 1, 2, 3, 4, 5]);
+        expect(() => batchMaker.getBatch(1)).toThrowError("index out-of-range");
+    })
+})

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -28,7 +28,7 @@
   "author": "Logion Team",
   "license": "Apache-2.0",
   "dependencies": {
-    "@logion/client-node": "^0.3.1-2",
+    "@logion/client-node": "^0.3.1-3",
     "@logion/csv": "workspace:^",
     "commander": "^11.1.0",
     "csv-parser": "^3.0.0",
@@ -49,6 +49,7 @@
     "eslint": "^8.20.0",
     "jasmine": "^4.3.0",
     "jasmine-spec-reporter": "^7.0.0",
+    "moq.ts": "^10.0.8",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
   },

--- a/packages/import/src/ImportCsv.ts
+++ b/packages/import/src/ImportCsv.ts
@@ -2,16 +2,20 @@ import { Command, Option, InvalidArgumentError } from "commander";
 import { ValidateCsv } from "./ValidateCsv.js";
 import { CsvItem, toItem, CsvItemWithFile } from "@logion/csv";
 import { UUID, Hash } from "@logion/node-api";
-import { Environment, EnvironmentString, FullSigner, HashOrContent, KeyringSigner, ClosedCollectionLoc, Signer, MimeType } from "@logion/client";
-import { newLogionClient, NodeFile } from "@logion/client-node";
+import { Environment, EnvironmentString, FullSigner, HashOrContent, KeyringSigner, ClosedCollectionLoc, Signer, MimeType, LogionClient } from "@logion/client";
+import { newLogionClient, NodeFile, NodeAxiosFileUploader } from "@logion/client-node";
 import { Keyring } from "@polkadot/api";
 import fs from "fs/promises";
+import { AddCollectionItemParams } from "@logion/client/dist/LocClient.js";
+import { BatchMaker } from "@logion/csv/dist/BatchMaker.js";
 
 export interface CsvImportParams {
     env: EnvironmentString,
     loc: UUID,
-    dir: string,
+    dir: string | undefined,
     suri: string,
+    batchSize: number,
+    local: boolean,
 }
 
 export class ImportCsv {
@@ -49,6 +53,14 @@ export class ImportCsv {
                 .makeOptionMandatory()
             )
             .addOption(new Option("--dir <dirPath>", "The directory used as input for files"))
+            .addOption(new Option("--batch-size <batchSize>", "The size of one batch (i.e. numbers of items in one extrinsic")
+                .default(10)
+                .argParser(parseInt)
+            )
+            .addOption(new Option("--local", "Connect to local node (--env value ignored)")
+                .hideHelp() // Reserved to developer
+                .implies({ env: "DEV" })
+            )
             .argument("<csvFiles...>", "the csv files to import")
             .action((csvFiles, csvImportParams) => this.importCsvFiles(csvImportParams, csvFiles))
             .description("To import one or more CSV file(s) into a Collection LOC")
@@ -56,7 +68,13 @@ export class ImportCsv {
 
     async importCsvFiles(csvImportParams: CsvImportParams, csvFiles: string []): Promise<void> {
 
-        const anonymousClient = await newLogionClient(csvImportParams.env);
+        const anonymousClient = csvImportParams.local ?
+            await LogionClient.create({
+                buildFileUploader: () => new NodeAxiosFileUploader(),
+                directoryEndpoint: "http://localhost:8090",
+                rpcEndpoints: [ "ws://127.0.0.1:9944" ],
+            }) :
+            await newLogionClient(csvImportParams.env);
 
         console.log("Logion Classification %s", anonymousClient.config.logionClassificationLoc);
         console.log("Creative Commons %s", anonymousClient.config.creativeCommonsLoc);
@@ -74,8 +92,9 @@ export class ImportCsv {
         });
         const collectionLoc = locsState.findById(csvImportParams.loc) as ClosedCollectionLoc;
         for (const csvFile of csvFiles) {
-            await this.importCsv(collectionLoc, csvFile, signer, csvImportParams.dir)
+            await this.importCsv(collectionLoc, csvFile, signer, csvImportParams)
         }
+        return anonymousClient.disconnect()
     }
 
     private async buildSigner(seedPath: string): Promise<{ signer: FullSigner, address: string }> {
@@ -86,44 +105,81 @@ export class ImportCsv {
         return { signer: new KeyringSigner(keyring), address };
     }
 
-    private async importCsv(collectionLoc: ClosedCollectionLoc, csvFile: string, signer: Signer, dir: string | undefined): Promise<void> {
+    private async importCsv(collectionLoc: ClosedCollectionLoc, csvFile: string, signer: Signer, csvImportParams: CsvImportParams): Promise<void> {
         const validated = await this.validateCsv.validateCsv(csvFile)
         if (validated) {
-            await this.importItems(collectionLoc, validated.items, signer, dir);
+            await this.importItems(collectionLoc, validated.items, signer, csvImportParams);
             console.log(`${ csvFile } imported`)
         } else {
             console.log(`${ csvFile } skipped`)
         }
     }
 
-    private async importItems(collectionLoc: ClosedCollectionLoc, items: CsvItem[], signer: Signer, dir: string | undefined): Promise<void> {
-        for (const item of items) {
-            await this.importItem(collectionLoc, item, signer, dir)
+    async importItems(collectionLoc: ClosedCollectionLoc, csvItems: CsvItem[], signer: Signer, csvImportParams: CsvImportParams): Promise<void> {
+        const { batchSize, dir } = csvImportParams
+        const batchMaker = new BatchMaker(csvItems, batchSize);
+        for (let i = 0; i < batchMaker.numOfBatches ; i++) {
+            const batch = batchMaker.getBatch(i);
+            console.log(`Importing batch ${ i + 1 } / ${ batchMaker.numOfBatches } (${ batch.length } rows)`)
+            await this.importItemBatch(collectionLoc, batch, signer, dir)
         }
     }
 
-    private async importItem(collection: ClosedCollectionLoc, csvItem: CsvItem, signer: Signer, dir: string | undefined): Promise<void> {
+    private async importItemBatch(collection: ClosedCollectionLoc, csvItems: CsvItem[], signer: Signer, dir: string | undefined): Promise<void> {
         const collectionAcceptsUpload = collection.data().collectionCanUpload !== undefined && collection.data().collectionCanUpload === true;
-        const item = toItem(csvItem, collectionAcceptsUpload);
-        const existingItem = await collection.getCollectionItem({ itemId: item.id as Hash });
-        if (existingItem) {
-            console.warn(`Skipping existing item ${ item.displayId }`)
-        } else {
-            console.log(`Importing new item ${ item.displayId }`)
-            await collection.addCollectionItem({
-                signer: signer!,
-                itemId: item.id!,
-                itemDescription: item.description,
-                itemFiles: item.files,
-                restrictedDelivery: item.restrictedDelivery,
-                itemToken: item.token,
-                logionClassification: item.logionClassification,
-                specificLicenses: item.specificLicense ? [ item.specificLicense ] : undefined,
-                creativeCommons: item.creativeCommons,
-            })
+        const payload: AddCollectionItemParams[] = [];
+        const items = csvItems.map(csvItem => toItem(csvItem, collectionAcceptsUpload));
+
+        for (let i = 0; i < items.length; i++ ) {
+            const item = items[i];
+            const existingItem = await collection.getCollectionItem({ itemId: item.id as Hash });
+            if (existingItem) {
+                console.warn(`Skipping existing item ${ item.displayId }`)
+                if (item.upload) {
+                    const csvItem = csvItems[i] as CsvItemWithFile;
+                    const file = existingItem.files.find(file => file.hash.equalTo(csvItem.fileHash));
+                    if (file) {
+                        if (file.uploaded) {
+                            items[i] = {
+                                ...item,
+                                upload: false
+                            }
+                        } else {
+                            console.warn(`File not uploaded yet.`)
+                        }
+                    } else {
+                        throw Error("Item exists without file entry")
+                    }
+                }
+
+            } else {
+                console.log(`Importing new item ${ item.displayId }`)
+                payload.push( {
+                    itemId: item.id!,
+                    itemDescription: item.description,
+                    itemFiles: item.files,
+                    restrictedDelivery: item.restrictedDelivery,
+                    itemToken: item.token,
+                    logionClassification: item.logionClassification,
+                    specificLicenses: item.specificLicense ? [ item.specificLicense ] : undefined,
+                    creativeCommons: item.creativeCommons,
+                });
+            }
         }
-        if (item.upload && dir) {
-            await this.uploadItemFile(collection, item.id!, csvItem as CsvItemWithFile, dir);
+
+        if (payload.length > 0) {
+            await collection.addCollectionItems({ signer, payload });
+        }
+
+        if (dir) {
+            for (let i = 0; i < items.length; i++ ) {
+                const item = items[i];
+                if (item.upload) {
+                    const csvItem = csvItems[i] as CsvItemWithFile;
+                    console.log(`Uploading ${ csvItem.fileName } linked to ${ item.displayId }`)
+                    await this.uploadItemFile(collection, item.id!, csvItem, dir);
+                }
+            }
         }
     }
 

--- a/packages/import/src/ImportCsv.ts
+++ b/packages/import/src/ImportCsv.ts
@@ -58,7 +58,6 @@ export class ImportCsv {
                 .argParser(parseInt)
             )
             .addOption(new Option("--local", "Connect to local node (--env value ignored)")
-                .hideHelp() // Reserved to developer
                 .implies({ env: "DEV" })
             )
             .argument("<csvFiles...>", "the csv files to import")
@@ -130,7 +129,7 @@ export class ImportCsv {
         const payload: AddCollectionItemParams[] = [];
         const items = csvItems.map(csvItem => toItem(csvItem, collectionAcceptsUpload));
 
-        for (let i = 0; i < items.length; i++ ) {
+        for (let i = 0; i < items.length; i++) {
             const item = items[i];
             const existingItem = await collection.getCollectionItem({ itemId: item.id as Hash });
             if (existingItem) {
@@ -172,7 +171,7 @@ export class ImportCsv {
         }
 
         if (dir) {
-            for (let i = 0; i < items.length; i++ ) {
+            for (let i = 0; i < items.length; i++) {
                 const item = items[i];
                 if (item.upload) {
                     const csvItem = csvItems[i] as CsvItemWithFile;

--- a/packages/import/test/ImportCsv.spec.ts
+++ b/packages/import/test/ImportCsv.spec.ts
@@ -73,7 +73,7 @@ describe("ImportCsv - importItems", () => {
 
     it("succeeds to add non-existing items without file", async () => {
         const collectionLoc = mockCollectionLoc({ itemsExists: false, collectionCanUpload: false });
-        await importCsv.importItems(collectionLoc.object(), csvItemsWithoutFile, signer, csvImportParams)
+        await importCsv.importItems(collectionLoc.object(), csvItemsWithoutFile, signer, csvImportParams);
         collectionLoc.verify(instance => instance.addCollectionItems(It.Is<BlockchainBatchSubmission<AddCollectionItemParams>>(params =>
                 params.payload[0].itemId.equalTo(Hash.of("1")) &&
                 params.payload[0].itemDescription === "some-description" &&
@@ -100,7 +100,7 @@ describe("ImportCsv - importItems", () => {
             fileHash: hashOrContent[index].contentHash,
             fileSize: hashOrContent[index].size.toString(),
         }))
-        await importCsv.importItems(collectionLoc.object(), csvItems, signer, csvImportParams)
+        await importCsv.importItems(collectionLoc.object(), csvItems, signer, csvImportParams);
         collectionLoc.verify(instance => instance.addCollectionItems(It.Is<BlockchainBatchSubmission<AddCollectionItemParams>>(params =>
                 params.payload[0].itemId.equalTo(Hash.of("1")) &&
                 params.payload[0].itemDescription === "some-description"
@@ -114,7 +114,7 @@ describe("ImportCsv - importItems", () => {
 
     it("skips existing items addition", async () => {
         const collectionLoc = mockCollectionLoc({ itemsExists: true, collectionCanUpload: false });
-        await importCsv.importItems(collectionLoc.object(), csvItemsWithoutFile, signer, csvImportParams)
+        await importCsv.importItems(collectionLoc.object(), csvItemsWithoutFile, signer, csvImportParams);
         collectionLoc.verify(instance => instance.addCollectionItems(It.IsAny<BlockchainBatchSubmission<AddCollectionItemParams>>()),
             Times.Never()
         );
@@ -136,7 +136,7 @@ describe("ImportCsv - importItems", () => {
             fileHash: hashOrContent[index].contentHash,
             fileSize: hashOrContent[index].size.toString(),
         }))
-        await importCsv.importItems(collectionLoc.object(), csvItems, signer, csvImportParams)
+        await importCsv.importItems(collectionLoc.object(), csvItems, signer, csvImportParams);
         collectionLoc.verify(instance => instance.addCollectionItems(It.IsAny<BlockchainBatchSubmission<AddCollectionItemParams>>()),
             Times.Never()
         );
@@ -156,7 +156,7 @@ function mockCollectionLoc(params: { itemsExists: boolean, collectionCanUpload: 
     if (itemsExists) {
         collectionItem.setup(instance => instance.files.find(It.IsAny())).returns(
             Promise.resolve({ uploaded: false })
-        )
+        );
     }
     collectionLoc.setup(instance => instance.data()).returns({
         collectionCanUpload

--- a/packages/import/test/ImportCsv.spec.ts
+++ b/packages/import/test/ImportCsv.spec.ts
@@ -1,0 +1,182 @@
+import { ParseOptions, Command } from "commander";
+import { ImportCsv, CsvImportParams } from "../src/ImportCsv.js";
+import { Mock, It, Times } from "moq.ts";
+import { ValidateCsv } from "../src/ValidateCsv.js";
+import { ClosedCollectionLoc, Signer, LocData, HashOrContent, MimeType } from "@logion/client";
+import { UUID, Hash } from "@logion/node-api";
+import { CsvItemWithoutFile, CsvItemWithFile } from "@logion/csv";
+import { BlockchainBatchSubmission, AddCollectionItemParams } from "@logion/client/dist/LocClient.js";
+import { UploadCollectionItemFileParams } from "@logion/client/dist/Loc.js";
+import { CollectionItem as CollectionItemClass } from "@logion/client/dist/CollectionItem.js";
+import { NodeFile } from "@logion/client-node";
+
+describe("ImportCsv - command", () => {
+
+    const parseOptions: ParseOptions = { from: "user" };
+
+    let command: Command;
+    beforeEach(() => {
+        const validateCsv = new Mock<ValidateCsv>;
+        const createCsv = new ImportCsv(validateCsv.object());
+        command = createCsv.command.exitOverride();
+    })
+
+    it("fails on wrong env", () => {
+        expect(() => command.parse([ "--env", "WRONG" ], parseOptions))
+            .toThrowError("error: option '--env <environment>' argument 'WRONG' is invalid. Allowed choices are DEV, TEST, MVP.")
+    })
+
+    it("fails on wrong LOC", () => {
+        expect(() => command.parse([ "--loc", "WRONG" ], parseOptions))
+            .toThrowError("error: option '--loc <locId>' argument 'WRONG' is invalid. Invalid collection LOC ID")
+    })
+
+    it("succeeds with valid options", () => {
+        command.parse([ "--loc", "6d5c886a-6350-4041-9205-afc2a67a6938", "--env", "DEV", "--suri", "my-suri", "file1.csv", "file2.csv", "file3.csv" ], parseOptions)
+    })
+})
+
+describe("ImportCsv - importItems", () => {
+
+    const csvImportParams: CsvImportParams = {
+        env: "DEV",
+        loc: new UUID("6d5c886a-6350-4041-9205-afc2a67a6938"),
+        suri: "my-suri",
+        batchSize: 5,
+        local: false,
+        dir: "./test/resources",
+    };
+    const signer = new Mock<Signer>().object();
+
+    const csvItemsWithoutFile: CsvItemWithoutFile[] = [
+        {
+            description: "some-description",
+            displayId: "1",
+            id: Hash.of("1"),
+            termsAndConditionsType: "CC4.0",
+            termsAndConditionsParameters: "BY-SA",
+        },
+        {
+            description: "some-other-description",
+            displayId: "2",
+            id: Hash.of("2"),
+            termsAndConditionsType: "CC4.0",
+            termsAndConditionsParameters: "BY-SA",
+        }
+    ];
+
+    let importCsv: ImportCsv
+    beforeEach(() => {
+        const validateCsv = new Mock<ValidateCsv>;
+        importCsv = new ImportCsv(validateCsv.object());
+    })
+
+    it("succeeds to add non-existing items without file", async () => {
+        const collectionLoc = mockCollectionLoc({ itemsExists: false, collectionCanUpload: false });
+        await importCsv.importItems(collectionLoc.object(), csvItemsWithoutFile, signer, csvImportParams)
+        collectionLoc.verify(instance => instance.addCollectionItems(It.Is<BlockchainBatchSubmission<AddCollectionItemParams>>(params =>
+                params.payload[0].itemId.equalTo(Hash.of("1")) &&
+                params.payload[0].itemDescription === "some-description" &&
+                params.payload[1].itemId.equalTo(Hash.of("2")) &&
+                params.payload[1].itemDescription === "some-other-description"
+            )),
+            Times.Once()
+        );
+        collectionLoc.verify(instance => instance.uploadCollectionItemFile(It.IsAny<UploadCollectionItemFileParams>()),
+            Times.Never()
+        );
+    })
+
+    it("succeeds to add non-existing items with file", async () => {
+        const collectionLoc = mockCollectionLoc({ itemsExists: false, collectionCanUpload: true });
+        const hashOrContent = [
+            await getFile(csvImportParams.dir!, "test-0.pdf"),
+            await getFile(csvImportParams.dir!, "test-1.pdf"),
+        ]
+        const csvItems: CsvItemWithFile[] = csvItemsWithoutFile.map((item, index) => ({
+            ...item,
+            fileName: hashOrContent[index].name,
+            fileContentType: hashOrContent[index].mimeType.mimeType,
+            fileHash: hashOrContent[index].contentHash,
+            fileSize: hashOrContent[index].size.toString(),
+        }))
+        await importCsv.importItems(collectionLoc.object(), csvItems, signer, csvImportParams)
+        collectionLoc.verify(instance => instance.addCollectionItems(It.Is<BlockchainBatchSubmission<AddCollectionItemParams>>(params =>
+                params.payload[0].itemId.equalTo(Hash.of("1")) &&
+                params.payload[0].itemDescription === "some-description"
+            )),
+            Times.Once()
+        );
+        collectionLoc.verify(instance => instance.uploadCollectionItemFile(It.IsAny<UploadCollectionItemFileParams>()),
+            Times.Exactly(2)
+        );
+    })
+
+    it("skips existing items addition", async () => {
+        const collectionLoc = mockCollectionLoc({ itemsExists: true, collectionCanUpload: false });
+        await importCsv.importItems(collectionLoc.object(), csvItemsWithoutFile, signer, csvImportParams)
+        collectionLoc.verify(instance => instance.addCollectionItems(It.IsAny<BlockchainBatchSubmission<AddCollectionItemParams>>()),
+            Times.Never()
+        );
+        collectionLoc.verify(instance => instance.uploadCollectionItemFile(It.IsAny<UploadCollectionItemFileParams>()),
+            Times.Never()
+        );
+    })
+
+    it("skips existing item addition but uploads file", async () => {
+        const collectionLoc = mockCollectionLoc({ itemsExists: true, collectionCanUpload: true });
+        const hashOrContent = [
+            await getFile(csvImportParams.dir!, "test-0.pdf"),
+            await getFile(csvImportParams.dir!, "test-1.pdf"),
+        ]
+        const csvItems: CsvItemWithFile[] = csvItemsWithoutFile.map((item, index) => ({
+            ...item,
+            fileName: hashOrContent[index].name,
+            fileContentType: hashOrContent[index].mimeType.mimeType,
+            fileHash: hashOrContent[index].contentHash,
+            fileSize: hashOrContent[index].size.toString(),
+        }))
+        await importCsv.importItems(collectionLoc.object(), csvItems, signer, csvImportParams)
+        collectionLoc.verify(instance => instance.addCollectionItems(It.IsAny<BlockchainBatchSubmission<AddCollectionItemParams>>()),
+            Times.Never()
+        );
+        collectionLoc.verify(instance => instance.uploadCollectionItemFile(It.IsAny<UploadCollectionItemFileParams>()),
+            Times.Exactly(2)
+        );
+    })
+
+
+})
+
+function mockCollectionLoc(params: { itemsExists: boolean, collectionCanUpload: boolean }): Mock<ClosedCollectionLoc> {
+    const { itemsExists, collectionCanUpload } = params;
+    const collectionLoc = new Mock<ClosedCollectionLoc>();
+
+    const collectionItem = new Mock<CollectionItemClass>();
+    if (itemsExists) {
+        collectionItem.setup(instance => instance.files.find(It.IsAny())).returns(
+            Promise.resolve({ uploaded: false })
+        )
+    }
+    collectionLoc.setup(instance => instance.data()).returns({
+        collectionCanUpload
+    } as LocData);
+    collectionLoc.setup(instance => instance.getCollectionItem(It.IsAny<Hash>())).returns(
+        itemsExists ? Promise.resolve(collectionItem.object()) : Promise.resolve(undefined)
+    )
+    collectionLoc.setup(instance => instance.addCollectionItems(It.IsAny<BlockchainBatchSubmission<AddCollectionItemParams>>())).returns(
+        Promise.resolve(collectionLoc.object())
+    );
+    collectionLoc.setup(instance => instance.uploadCollectionItemFile(It.IsAny<UploadCollectionItemFileParams>())).returns(
+        Promise.resolve(collectionLoc.object())
+    );
+    return collectionLoc
+}
+
+async function getFile(dir: string, name: string): Promise<HashOrContent> {
+    const nodeFile = new NodeFile(`${ dir }/${ name }`, name, MimeType.from("application/pdf"));
+    const hashOrContent = HashOrContent.fromContent(nodeFile);
+    await hashOrContent.finalize();
+    return hashOrContent
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,25 +141,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/client-node@npm:^0.3.1-2":
-  version: 0.3.1-2
-  resolution: "@logion/client-node@npm:0.3.1-2"
+"@logion/client-node@npm:^0.3.1-3":
+  version: 0.3.1-3
+  resolution: "@logion/client-node@npm:0.3.1-3"
   dependencies:
-    "@logion/client": ^0.36.1-1
+    "@logion/client": ^0.37.0-1
     form-data: ^4.0.0
-  checksum: d540dbaba0461fc29b922ce1f8aa23314fde117f27eddb7ae01a579ac47b60b31bc0a93990bbff5efc784682d1db256f88bf2e6d82042c0c2c503660e1991742
+  checksum: f0abd04323c486dd2d39f377314e4d51b1c0d253b02e0aac7672e0301b345f203c2a1499e191070eeee0d3c1e77a5bc18ae4a1dd82318d87b6360f3a013fbf4c
   languageName: node
   linkType: hard
 
-"@logion/client@npm:^0.36.1-1":
-  version: 0.36.1-1
-  resolution: "@logion/client@npm:0.36.1-1"
+"@logion/client@npm:^0.37.0-1":
+  version: 0.37.0-1
+  resolution: "@logion/client@npm:0.37.0-1"
   dependencies:
-    "@logion/node-api": ^0.26.0
+    "@logion/node-api": ^0.27.0-2
     axios: ^0.27.2
     luxon: ^3.0.1
     mime-db: ^1.52.0
-  checksum: 9c6b37bf35b4f6e67916ce97c5938db4fe770ab0fef69e72bd06dbd0a95e832359a3f59f191ab67e8fbf5a2369ade5f5b05d2dc466e1a95034ca3b7679b35623
+  checksum: e6e567ed8d291f87ca98b2e779ff2bbef446143d7479d9426bc7d30f6adee7af4a1a3db84f36377f375ba8d06747a0f09769dd221817afcbf66427e00001c852
   languageName: node
   linkType: hard
 
@@ -167,7 +167,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@logion/csv@workspace:packages/csv"
   dependencies:
-    "@logion/node-api": ^0.26.0
+    "@logion/node-api": ^0.27.0-2
     "@tsconfig/node18": ^1.0.1
     "@types/jasmine": ^4.0.3
     "@types/node": ^18.6.1
@@ -185,7 +185,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@logion/import@workspace:packages/import"
   dependencies:
-    "@logion/client-node": ^0.3.1-2
+    "@logion/client-node": ^0.3.1-3
     "@logion/csv": "workspace:^"
     "@tsconfig/node18": ^1.0.1
     "@types/figlet": ^1.5.8
@@ -200,6 +200,7 @@ __metadata:
     figlet: ^1.7.0
     jasmine: ^4.3.0
     jasmine-spec-reporter: ^7.0.0
+    moq.ts: ^10.0.8
     ts-node: ^10.9.1
     typescript: ^4.9.5
   bin:
@@ -207,9 +208,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@logion/node-api@npm:^0.26.0":
-  version: 0.26.0
-  resolution: "@logion/node-api@npm:0.26.0"
+"@logion/node-api@npm:^0.27.0-2":
+  version: 0.27.0-2
+  resolution: "@logion/node-api@npm:0.27.0-2"
   dependencies:
     "@polkadot/api": ^10.10.1
     "@polkadot/util": ^12.5.1
@@ -217,7 +218,7 @@ __metadata:
     "@types/uuid": ^9.0.2
     fast-sha256: ^1.3.0
     uuid: ^9.0.0
-  checksum: 4024cf6911e20cf345d9e506ce7dd33e2b29340adce8be384f26df3d4e4ebb34e9b42ddc1cfe3d57e9585bb735749d26d9eb789ceacba6257e38958d0fe47c83
+  checksum: 37765ae5ee9f97c515886d944e371153de395a883c7af3ba1386e9eee87ede8293b5ceaaea36ed7f5cc191adf5cea5c94e18d3b953504848ee2791c3f7041782
   languageName: node
   linkType: hard
 
@@ -1880,6 +1881,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"moq.ts@npm:^10.0.8":
+  version: 10.1.0
+  resolution: "moq.ts@npm:10.1.0"
+  dependencies:
+    tslib: "*"
+  checksum: 7598aae4f69fd1a3f58cb22613fafbd3b978af0f15bf93790d55b966f6710172631da9540ada454704ac2a47c214d1d5d095d988d26674573d70cf1c20a4b429
+  languageName: node
+  linkType: hard
+
 "ms@npm:2.1.2":
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
@@ -2216,7 +2226,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.6.2":
+"tslib@npm:*, tslib@npm:^2.1.0, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad


### PR DESCRIPTION
* Use batching to submit collection items. Batch size is 10, configurable with option `--batch-size`.
* Import of a given CSV file may be stopped/resumed.
* Developers may use the undocumented option `--local`, to connect to local rpc and directory (as configured in `logion-test`).
* Missing tests are added.

logion-network/logion-internal#1107